### PR TITLE
Add global lock B+ Tree, along with some simple benchmarking infra

### DIFF
--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -81,7 +81,7 @@ func RunFindBenchmark(tree tree_api.BPTree, numKeys int, threads int) (time.Dura
 	}
 	elapsedTime := time.Since(startTime)
 	throughput := float64(numKeys) / elapsedTime.Seconds()
-	fmt.Printf("Delete %d keys in %f seconds with %d threads, throughput: %f keys/s\n", numKeys, elapsedTime.Seconds(), threads, throughput)
+	fmt.Printf("Find %d keys in %f seconds with %d threads, throughput: %f keys/s\n", numKeys, elapsedTime.Seconds(), threads, throughput)
 	return elapsedTime, throughput
 }
 

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -1,0 +1,111 @@
+package benchmark
+
+import (
+	"fmt"
+	"main/tree_api"
+	"math/rand"
+	"time"
+)
+
+func insertKeys(tree tree_api.BPTree, startIndex, endIndex int, threadId int, keys []int) {
+	for i := startIndex; i < endIndex; i++ {
+		tree.Insert(keys[i], []byte("value"))
+	}
+}
+
+func deleteKeys(tree tree_api.BPTree, startIndex, endIndex int, threadId int, keys []int) {
+	for i := startIndex; i < endIndex; i++ {
+		tree.Delete(keys[i])
+	}
+}
+
+func findKeys(tree tree_api.BPTree, startIndex, endIndex int, threadId int, keys []int) {
+	for i := startIndex; i < endIndex; i++ {
+		tree.Find(keys[i], false)
+	}
+}
+
+func makeShuffledKeysList(numKeys int) []int {
+	keys := make([]int, numKeys)
+	for i := 0; i < numKeys; i++ {
+		keys[i] = i
+	}
+	// Shuffle keys
+	rand.Shuffle(len(keys), func(i, j int) { keys[i], keys[j] = keys[j], keys[i] })
+	return keys
+}
+
+func RunInsertBenchmark(tree tree_api.BPTree, numKeys int, threads int) (time.Duration, float64) {
+	done := make(chan bool)
+	numKeysPerThread := numKeys / threads
+	keys := makeShuffledKeysList(numKeys)
+	startTime := time.Now()
+	for i := 0; i < threads; i++ {
+		go func(index int) {
+			startIndex := index * numKeysPerThread
+			endIndex := startIndex + numKeysPerThread
+			if endIndex > numKeys {
+				endIndex = numKeys
+			}
+			insertKeys(tree, startIndex, endIndex, index, keys)
+			done <- true
+		}(i)
+	}
+	for doneCount := 0; doneCount < threads; doneCount++ {
+		<-done
+	}
+	elapsedTime := time.Since(startTime)
+	throughput := float64(numKeys) / elapsedTime.Seconds()
+	fmt.Printf("Insert %d keys in %f seconds with %d threads, throughput: %f keys/s\n", numKeys, elapsedTime.Seconds(), threads, throughput)
+	return elapsedTime, throughput
+}
+
+func RunFindBenchmark(tree tree_api.BPTree, numKeys int, threads int) (time.Duration, float64) {
+	done := make(chan bool)
+	numKeysPerThread := numKeys / threads
+	keys := makeShuffledKeysList(numKeys)
+	startTime := time.Now()
+	for i := 0; i < threads; i++ {
+		go func(index int) {
+			startIndex := index * numKeysPerThread
+			endIndex := startIndex + numKeysPerThread
+			if endIndex > numKeys {
+				endIndex = numKeys
+			}
+			findKeys(tree, startIndex, endIndex, index, keys)
+			done <- true
+		}(i)
+	}
+	for doneCount := 0; doneCount < threads; doneCount++ {
+		<-done
+	}
+	elapsedTime := time.Since(startTime)
+	throughput := float64(numKeys) / elapsedTime.Seconds()
+	fmt.Printf("Delete %d keys in %f seconds with %d threads, throughput: %f keys/s\n", numKeys, elapsedTime.Seconds(), threads, throughput)
+	return elapsedTime, throughput
+}
+
+func RunDeleteBenchmark(tree tree_api.BPTree, numKeys int, threads int) (time.Duration, float64) {
+	done := make(chan bool)
+	numKeysPerThread := numKeys / threads
+	keys := makeShuffledKeysList(numKeys)
+	startTime := time.Now()
+	for i := 0; i < threads; i++ {
+		go func(index int) {
+			startIndex := index * numKeysPerThread
+			endIndex := startIndex + numKeysPerThread
+			if endIndex > numKeys {
+				endIndex = numKeys
+			}
+			deleteKeys(tree, startIndex, endIndex, index, keys)
+			done <- true
+		}(i)
+	}
+	for doneCount := 0; doneCount < threads; doneCount++ {
+		<-done
+	}
+	elapsedTime := time.Since(startTime)
+	throughput := float64(numKeys) / elapsedTime.Seconds()
+	fmt.Printf("Delete %d keys in %f seconds with %d threads, throughput: %f keys/s\n", numKeys, elapsedTime.Seconds(), threads, throughput)
+	return elapsedTime, throughput
+}

--- a/global_lock_tree/tree.go
+++ b/global_lock_tree/tree.go
@@ -1,0 +1,58 @@
+package global_lock_tree
+
+import (
+	"main/seq_tree"
+	"main/tree_api"
+	"sync"
+)
+
+type GlobalLockTree struct {
+	tree *seq_tree.Tree
+	lock sync.Mutex
+}
+
+func NewTree() tree_api.BPTree {
+	return &GlobalLockTree{tree: seq_tree.NewTree(), lock: sync.Mutex{}}
+}
+
+func (t *GlobalLockTree) Insert(key int, value []byte) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.tree.Insert(key, value)
+}
+
+func (t *GlobalLockTree) Delete(key int) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.tree.Delete(key)
+}
+
+func (t *GlobalLockTree) Find(key int, verbose bool) (*tree_api.Record, error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.tree.Find(key, verbose)
+}
+
+func (t *GlobalLockTree) PrintTree() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.tree.PrintTree()
+}
+
+func (t *GlobalLockTree) FindAndPrint(key int, verbose bool) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.tree.FindAndPrint(key, verbose)
+}
+
+func (t *GlobalLockTree) FindAndPrintRange(key_start, key_end int, verbose bool) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.tree.FindAndPrintRange(key_start, key_end, verbose)
+}
+
+func (t *GlobalLockTree) PrintLeaves() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.tree.PrintLeaves()
+}

--- a/main.go
+++ b/main.go
@@ -2,14 +2,49 @@ package main
 
 import (
 	"fmt"
+	"main/benchmark"
+	"main/global_lock_tree"
 	"main/seq_tree"
 )
 
 func main() {
-	tree := seq_tree.NewTree()
-	values := []byte("test")
-	for i := 0; i < 1000000; i++ {
-		tree.Insert(i, values)
+	keyCount := 2500000
+	seqTree := seq_tree.NewTree()
+	// globalLockTree := global_lock_tree.NewTree()
+	fmt.Println("Sequential Tree Insert Benchmark")
+	benchmark.RunInsertBenchmark(seqTree, keyCount, 1)
+	fmt.Println("Global Lock Tree Insert Benchmark")
+	seqGlobalTree := global_lock_tree.NewTree()
+	duration, _ := benchmark.RunInsertBenchmark(seqGlobalTree, keyCount, 1)
+	bigTrees := []*global_lock_tree.GlobalLockTree{}
+	bigTrees = append(bigTrees, seqGlobalTree.(*global_lock_tree.GlobalLockTree))
+	for threadCount := 2; threadCount <= 64; threadCount *= 2 {
+		tree := global_lock_tree.NewTree()
+		newDuration, _ := benchmark.RunInsertBenchmark(tree, keyCount, threadCount)
+		fmt.Printf("Speedup over sequential: %f\n", duration.Seconds()/newDuration.Seconds())
+		bigTrees = append(bigTrees, tree.(*global_lock_tree.GlobalLockTree))
 	}
-	fmt.Println("Done")
+	fmt.Println("Sequential Tree Find Benchmark")
+	benchmark.RunFindBenchmark(seqTree, keyCount, 1)
+
+	fmt.Println("Global Lock Tree Find Benchmark")
+	duration, _ = benchmark.RunFindBenchmark(seqGlobalTree, keyCount, 1)
+	treeIdx := 0
+	for threadCount := 2; threadCount <= 64; threadCount *= 2 {
+		newDuration, _ := benchmark.RunFindBenchmark(bigTrees[treeIdx], keyCount, threadCount)
+		fmt.Printf("Speedup over sequential: %f\n", duration.Seconds()/newDuration.Seconds())
+		treeIdx++
+	}
+	treeIdx = 0
+	fmt.Println("Sequential Tree Delete Benchmark")
+	benchmark.RunDeleteBenchmark(seqTree, keyCount, 1)
+
+	fmt.Println("Global Lock Tree Delete Benchmark")
+	duration, _ = benchmark.RunDeleteBenchmark(seqGlobalTree, keyCount, 1)
+	for threadCount := 2; threadCount <= 64; threadCount *= 2 {
+		newDuration, _ := benchmark.RunDeleteBenchmark(bigTrees[treeIdx], keyCount, threadCount)
+		fmt.Printf("Speedup over sequential: %f\n", duration.Seconds()/newDuration.Seconds())
+		treeIdx++
+	}
+
 }

--- a/seq_tree/tree.go
+++ b/seq_tree/tree.go
@@ -1,8 +1,10 @@
 package seq_tree
+
 // From https://github.com/collinglass/bptree
 import (
 	"errors"
 	"fmt"
+	"main/tree_api"
 	"reflect"
 )
 
@@ -23,10 +25,6 @@ type Tree struct {
 	Root *Node
 }
 
-type Record struct {
-	Value []byte
-}
-
 type Node struct {
 	Pointers []interface{}
 	Keys     []int
@@ -41,7 +39,7 @@ func NewTree() *Tree {
 }
 
 func (t *Tree) Insert(key int, value []byte) error {
-	var pointer *Record
+	var pointer *tree_api.Record
 	var leaf *Node
 
 	if _, err := t.Find(key, false); err == nil {
@@ -67,7 +65,7 @@ func (t *Tree) Insert(key int, value []byte) error {
 	return t.insertIntoLeafAfterSplitting(leaf, key, pointer)
 }
 
-func (t *Tree) Find(key int, verbose bool) (*Record, error) {
+func (t *Tree) Find(key int, verbose bool) (*tree_api.Record, error) {
 	i := 0
 	c := t.findLeaf(key, verbose)
 	if c == nil {
@@ -82,7 +80,7 @@ func (t *Tree) Find(key int, verbose bool) (*Record, error) {
 		return nil, errors.New("key not found")
 	}
 
-	r, _ := c.Pointers[i].(*Record)
+	r, _ := c.Pointers[i].(*tree_api.Record)
 
 	return r, nil
 }
@@ -107,7 +105,7 @@ func (t *Tree) FindAndPrintRange(key_start, key_end int, verbose bool) {
 		fmt.Println("None found,")
 	} else {
 		for i = 0; i < num_found; i++ {
-			c, _ := returned_pointers[i].(*Record)
+			c, _ := returned_pointers[i].(*tree_api.Record)
 			fmt.Printf("Key: %d  Location: %d  Value: %s\n",
 				returned_keys[i],
 				returned_pointers[i],
@@ -326,8 +324,8 @@ func cut(length int) int {
 }
 
 // INSERTION
-func makeRecord(value []byte) (*Record, error) {
-	new_record := new(Record)
+func makeRecord(value []byte) (*tree_api.Record, error) {
+	new_record := new(tree_api.Record)
 	if new_record == nil {
 		return nil, errors.New("Error: Record creation.")
 	} else {
@@ -373,7 +371,7 @@ func getLeftIndex(parent, left *Node) int {
 	return left_index
 }
 
-func insertIntoLeaf(leaf *Node, key int, pointer *Record) {
+func insertIntoLeaf(leaf *Node, key int, pointer *tree_api.Record) {
 	var i, insertion_point int
 
 	for insertion_point < leaf.NumKeys && leaf.Keys[insertion_point] < key {
@@ -390,7 +388,7 @@ func insertIntoLeaf(leaf *Node, key int, pointer *Record) {
 	return
 }
 
-func (t *Tree) insertIntoLeafAfterSplitting(leaf *Node, key int, pointer *Record) error {
+func (t *Tree) insertIntoLeafAfterSplitting(leaf *Node, key int, pointer *tree_api.Record) error {
 	var new_leaf *Node
 	var insertion_index, split, new_key, i, j int
 	var err error
@@ -570,7 +568,7 @@ func (t *Tree) insertIntoNewRoot(left *Node, key int, right *Node) error {
 	return nil
 }
 
-func (t *Tree) startNewTree(key int, pointer *Record) error {
+func (t *Tree) startNewTree(key int, pointer *tree_api.Record) error {
 	t.Root, err = makeLeaf()
 	if err != nil {
 		return err

--- a/tree_api/tree_api.go
+++ b/tree_api/tree_api.go
@@ -1,0 +1,14 @@
+package tree_api
+
+type Record struct {
+	Value []byte
+}
+
+type BPTree interface {
+	Insert(key int, value []byte) error
+	Delete(key int) error
+	Find(key int, verbose bool) (*Record, error)
+	// PrintTree()
+	// FindAndPrint(key int, verbose bool)
+	// FindAndPrintRange(key_start, key_end int, verbose bool)
+}


### PR DESCRIPTION
Implements a thread-safe wrapper of the base B+ tree, and adds some basic benchmarking code to evaluate throughput and speedup. 

Sample output:
```sh
$ go run main.go
Sequential Tree Insert Benchmark
Insert 2500000 keys in 4.392532 seconds with 1 threads, throughput: 569147.833446 keys/s
Global Lock Tree Insert Benchmark
Insert 2500000 keys in 4.278491 seconds with 1 threads, throughput: 584318.145571 keys/s
Insert 2500000 keys in 4.803505 seconds with 2 threads, throughput: 520453.298552 keys/s
Speedup over sequential: 0.890702
Insert 2500000 keys in 5.100128 seconds with 4 threads, throughput: 490183.787794 keys/s
Speedup over sequential: 0.838899
Insert 2500000 keys in 5.016484 seconds with 8 threads, throughput: 498357.057915 keys/s
Speedup over sequential: 0.852886
Insert 2500000 keys in 5.211840 seconds with 16 threads, throughput: 479677.000796 keys/s
Speedup over sequential: 0.820918
Insert 2500000 keys in 4.757055 seconds with 32 threads, throughput: 525535.268255 keys/s
Speedup over sequential: 0.899399
Insert 2500000 keys in 7.078619 seconds with 64 threads, throughput: 353176.219383 keys/s
Speedup over sequential: 0.604425
Sequential Tree Find Benchmark
Find 2500000 keys in 3.872247 seconds with 1 threads, throughput: 645619.902713 keys/s
Global Lock Tree Find Benchmark
Find 2500000 keys in 3.790276 seconds with 1 threads, throughput: 659582.523120 keys/s
Find 2500000 keys in 4.557000 seconds with 2 threads, throughput: 548606.489188 keys/s
Speedup over sequential: 0.831748
Find 2500000 keys in 7.865436 seconds with 4 threads, throughput: 317846.339317 keys/s
Speedup over sequential: 0.481890
Find 2500000 keys in 5.579091 seconds with 8 threads, throughput: 448101.640924 keys/s
Speedup over sequential: 0.679372
Find 2500000 keys in 5.245448 seconds with 16 threads, throughput: 476603.714306 keys/s
Speedup over sequential: 0.722584
Find 2500000 keys in 5.087901 seconds with 32 threads, throughput: 491361.765912 keys/s
Speedup over sequential: 0.744959
Find 2500000 keys in 4.643180 seconds with 64 threads, throughput: 538424.131023 keys/s
Speedup over sequential: 0.816310
Sequential Tree Delete Benchmark
Delete 2500000 keys in 7.514327 seconds with 1 threads, throughput: 332697.812154 keys/s
Global Lock Tree Delete Benchmark
Delete 2500000 keys in 6.956033 seconds with 1 threads, throughput: 359400.263031 keys/s
Delete 2500000 keys in 4.198605 seconds with 2 threads, throughput: 595435.930102 keys/s
Speedup over sequential: 1.656749
Delete 2500000 keys in 8.156666 seconds with 4 threads, throughput: 306497.785217 keys/s
Speedup over sequential: 0.852803
Delete 2500000 keys in 9.050601 seconds with 8 threads, throughput: 276224.748876 keys/s
Speedup over sequential: 0.768571
Delete 2500000 keys in 11.052108 seconds with 16 threads, throughput: 226201.183150 keys/s
Speedup over sequential: 0.629385
Delete 2500000 keys in 9.844566 seconds with 32 threads, throughput: 253947.190057 keys/s
Speedup over sequential: 0.706586
Delete 2500000 keys in 7.662935 seconds with 64 threads, throughput: 326245.751308 keys/s
Speedup over sequential: 0.907750
```